### PR TITLE
close dockers when segmentation fault

### DIFF
--- a/Src/AppWindow.cpp
+++ b/Src/AppWindow.cpp
@@ -15,6 +15,7 @@ namespace spqr {
 AppWindow::AppWindow(int& argc, char** argv) {
     std::signal(SIGTERM, signalHandler);
     std::signal(SIGINT, signalHandler);
+    std::signal(SIGSEGV, signalHandler);
 
     resize(spqr::initialWindowWidth, spqr::initialWindowHeight);
     setWindowTitle(spqr::appName);


### PR DESCRIPTION
Signal handler close docker when occurs a segmentation fault into the code.

could not verify with `kill -SEGV <pid>`  ( #43  ) because for some strange reason doesn't happend nothing, I tested this when error raised in #45 and it worked